### PR TITLE
Writer rework

### DIFF
--- a/ctt.py
+++ b/ctt.py
@@ -60,8 +60,8 @@ def main(**kwargs):
             h.make_jobs()
         except IOError:
             sys.exit(1)
-        except Exception as e:
-            logging.error(repr(e))
+        except Exception:
+            logging.exception('Error')
 
 if __name__ == "__main__":
     main()

--- a/src/CTTFormatter.py
+++ b/src/CTTFormatter.py
@@ -11,10 +11,11 @@ class CTTFormatter(logging.Formatter):
         return "\033[31m%s\033[39m" % arg
 
     def format(self, record):
+        msg = super(CTTFormatter, self).format(record)
         if record.levelno == logging.WARNING:
-            return self.__orange(record.msg)
+            return self.__orange(msg)
         elif (record.levelno == logging.ERROR or
               record.levelno == logging.CRITICAL):
-            return self.__red(record.msg)
+            return self.__red(msg)
         else:
-            return record.msg
+            return msg

--- a/src/crawlers.py
+++ b/src/crawlers.py
@@ -1,0 +1,125 @@
+import logging
+import requests
+
+
+class BaseError(Exception):
+    pass
+
+
+class InvalidParameterError(BaseError):
+    pass
+
+
+class RemoteEmptyError(BaseError):
+    pass
+
+
+class RemoteAccessError(BaseError):
+    pass
+
+
+class CTTCrawler(object):
+
+    def __init__(self, cfg):
+        self._cfg = cfg
+
+    def __get_image_name(self, board):
+        if board['arch'] == 'arm':
+            return 'zImage'
+        elif board['arch'] == 'arm64':
+            return 'Image'
+
+        raise InvalidParameterError('Unknown architecture')
+
+    def _get_latest_release(self, tree, branch):
+        raise NotImplementedError('Missing release retrieval function')
+
+    def _get_base_url(self, tree, branch, arch, defconfig):
+        raise NotImplementedError('Missing base URL retrieval function')
+
+    def crawl(self, board, tree, branch, defconfig):
+        logging.debug('%s: Looking for artifacts for board %s, defconfig %s' %
+                      (self.__class__.__name__, board['name'], defconfig))
+
+        url = self._get_base_url(tree, branch, board['arch'], defconfig)
+        r = requests.get(url)
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            raise RemoteAccessError(
+                'Defconfig build not available for this version')
+
+        kernel = '%s/%s' % (url, self.__get_image_name(board))
+        r = requests.get(kernel)
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            raise RemoteAccessError(
+                'Kernel image not available for this version')
+
+        modules = '%s/%s' % (url, 'modules.tar.xz')
+        r = requests.get(modules)
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            raise RemoteAccessError(
+                'modules tarball not available for this version')
+
+        dtb = '%s/dtbs/%s.dtb' % (url, board['dt'])
+        r = requests.get(dtb)
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            raise RemoteAccessError(
+                'Device Tree not available for this version')
+
+        return {
+            'dtb': dtb,
+            'kernel': kernel,
+            'modules': modules,
+        }
+
+
+class FreeElectronsCrawler(CTTCrawler):
+    __BASE_URL = 'http://lava.free-electrons.com/downloads/builds/'
+
+    def _get_base_url(self, tree, branch, arch, defconfig):
+        return '%s/%s/%s/%s/%s/%s' % (self.__BASE_URL, tree, branch,
+                                      self._get_latest_release(tree, branch),
+                                      arch, defconfig)
+
+    def _get_latest_release(self, tree, branch):
+        url = '%s/%s/%s/latest' % (self.__BASE_URL, tree, branch)
+        r = requests.get(url)
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            raise RemoteAccessError('Release page not accessible')
+
+        return r.text
+
+
+class KernelCICrawler(CTTCrawler):
+    __BASE_URL = 'https://storage.kernelci.org/'
+    __RELEASE_URL = 'https://api.kernelci.org/build?limit=1&job=%s&field=kernel&sort=created_on&git_branch=%s'
+
+    def _get_base_url(self, tree, branch, arch, defconfig):
+        return '%s/%s/%s/%s/%s/%s' % (self.__BASE_URL, tree, branch,
+                                      self._get_latest_release(tree, branch),
+                                      arch, defconfig)
+
+    def _get_latest_release(self, tree, branch):
+        try:
+            r = requests.get(self.__RELEASE_URL % (tree, branch),
+                             headers={'Authorization': self._cfg['api_token']})
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            raise RemoteAccessError('Release page not accessible')
+
+        json = r.json()
+        if ('result' not in json or
+            len(json['result']) == 0 or
+                'kernel' not in json['result'][0]):
+            raise RemoteEmptyError('No release found')
+
+        return json['result'][0]['kernel']

--- a/src/writers.py
+++ b/src/writers.py
@@ -1,0 +1,84 @@
+import logging
+import os
+import urllib
+import xmlrpc.client
+
+
+class BaseError(Exception):
+    pass
+
+
+class UnavailableError(BaseError):
+    pass
+
+
+class Writer(object):
+
+    def __init__(self, cfg):
+        self._cfg = cfg
+
+    def write(self, board, name, job):
+        raise NotImplementedError('Missing write method')
+
+
+class FileWriter(Writer):
+
+    def write(self, board, name, job):
+        try:
+            os.makedirs(self._cfg['output_dir'])
+        except:
+            pass
+
+        out = os.path.join(self._cfg['output_dir'], '%s.yaml' % name)
+        try:
+            f = open(out, 'w')
+            f.write(job)
+        except IOError:
+            raise UnavailableError('Couldn\'t save our file')
+
+        return [out]
+
+
+class LavaWriter(Writer):
+
+    def __init__(self, cfg):
+        self._cfg = cfg
+
+        try:
+            u = urllib.parse.urlparse(self._cfg['server'])
+            url = "%s://%s:%s@%s/RPC2" % (u.scheme,
+                                          self._cfg['username'],
+                                          self._cfg['token'],
+                                          u.netloc)
+
+            self._con = xmlrpc.client.ServerProxy(url)
+        except xmlrpc.client.Error:
+            raise UnavailableError('LAVA device is offline')
+
+    def __get_device_status(self, device):
+        board = "%s_01" % device
+
+        return self._con.scheduler.get_device_status(board)
+
+    def write(self, board, name, job):
+        dev = self.__get_device_status(board['device_type'])
+        if dev['status'] == "offline":
+            logging.error("Device is offline, not sending the job")
+            raise UnavailableError('LAVA device is offline')
+
+        value = list()
+        #
+        # submit_job can return either an int (if there's one element)
+        # or a list of them (if it's a multinode job).
+        # This is crappy, but the least crappy way to handle this.
+        #
+        ret = self._con.scheduler.submit_job(job)
+        try:
+            for r in ret:
+                value.append('%s/scheduler/job/%s' %
+                             (self._cfg['web_ui_address'], r))
+        except TypeError:
+            value.append('%s/scheduler/job/%s' %
+                         (self._cfg['web_ui_address'], ret))
+
+        return value

--- a/tests/test_crawlers.py
+++ b/tests/test_crawlers.py
@@ -1,0 +1,557 @@
+import requests
+import requests_mock
+from nose.tools import assert_equal, assert_raises
+
+from crawlers import FreeElectronsCrawler, KernelCICrawler
+from crawlers import RemoteAccessError, RemoteEmptyError
+
+
+class TestKernelCICrawler(object):
+    BASE_URL = 'https://storage.kernelci.org/'
+    RELEASE_URL = 'https://api.kernelci.org/build?limit=1&job=%s&field=kernel&sort=created_on&git_branch=%s'
+    DEFAULT_API_TOKEN = 'foobar42'
+    DEFAULT_ARCH = 'arm'
+    DEFAULT_BRANCH = 'master'
+    DEFAULT_DEFCONFIG = 'test_defconfig'
+    DEFAULT_DTB = 'test'
+    DEFAULT_IMAGE = 'zImage'
+    DEFAULT_MODULES = 'modules.tar.xz'
+    DEFAULT_RELEASE = 'version-deadcoffee-4.2'
+    DEFAULT_TREE = 'mainline'
+
+    @requests_mock.mock()
+    def test_check_release(self, mock):
+        url = self.RELEASE_URL % (self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+        response = {
+            'result': [{'kernel': self.DEFAULT_RELEASE}],
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+        headers = {
+            'Authorization': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(url, json=response, request_headers=headers)
+
+        crawler = KernelCICrawler(cfg)
+        assert_equal(self.DEFAULT_RELEASE,
+                     crawler._get_latest_release(self.DEFAULT_TREE,
+                                                 self.DEFAULT_BRANCH))
+
+    @requests_mock.mock()
+    def test_check_release_error(self, mock):
+        url = self.RELEASE_URL % (self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(url, status_code=404)
+
+        crawler = KernelCICrawler(cfg)
+        assert_raises(RemoteAccessError, crawler._get_latest_release,
+                      self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+
+    @requests_mock.mock()
+    def test_check_release_missing_result(self, mock):
+        url = self.RELEASE_URL % (self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+        response = {
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+        headers = {
+            'Authorization': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(url, json=response, request_headers=headers)
+
+        crawler = KernelCICrawler(cfg)
+        assert_raises(RemoteEmptyError, crawler._get_latest_release,
+                      self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+
+    @requests_mock.mock()
+    def test_check_release_empty_result(self, mock):
+        url = self.RELEASE_URL % (self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+        response = {
+            'result': list(),
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+        headers = {
+            'Authorization': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(url, json=response, request_headers=headers)
+
+        crawler = KernelCICrawler(cfg)
+        assert_raises(RemoteEmptyError, crawler._get_latest_release,
+                      self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+
+    @requests_mock.mock()
+    def test_check_release_missing_result_kernel(self, mock):
+        url = self.RELEASE_URL % (self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+        response = {
+            'result': [{'test': 'test'}],
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+        headers = {
+            'Authorization': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(url, json=response, request_headers=headers)
+
+        crawler = KernelCICrawler(cfg)
+        assert_raises(RemoteEmptyError, crawler._get_latest_release,
+                      self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+
+    @requests_mock.mock()
+    def test_check_release_url(self, mock):
+        url = self.RELEASE_URL % (self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+        base_url = '%s/%s/%s/%s/%s/%s' % (self.BASE_URL,
+                                          self.DEFAULT_TREE,
+                                          self.DEFAULT_BRANCH,
+                                          self.DEFAULT_RELEASE,
+                                          self.DEFAULT_ARCH,
+                                          self.DEFAULT_DEFCONFIG)
+        response = {
+            'result': [{'kernel': self.DEFAULT_RELEASE}],
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+        headers = {
+            'Authorization': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(url, json=response, request_headers=headers)
+
+        crawler = KernelCICrawler(cfg)
+        assert_equal(base_url, crawler._get_base_url(self.DEFAULT_TREE,
+                                                     self.DEFAULT_BRANCH,
+                                                     self.DEFAULT_ARCH,
+                                                     self.DEFAULT_DEFCONFIG))
+
+    @requests_mock.mock()
+    def test_check_artifacts_all(self, mock):
+        release_url = self.RELEASE_URL % (self.DEFAULT_TREE,
+                                          self.DEFAULT_BRANCH)
+        config_url = '%s/%s/%s/%s/%s/%s' % (self.BASE_URL,
+                                            self.DEFAULT_TREE,
+                                            self.DEFAULT_BRANCH,
+                                            self.DEFAULT_RELEASE,
+                                            self.DEFAULT_ARCH,
+                                            self.DEFAULT_DEFCONFIG)
+        kernel_url = '%s/%s' % (config_url, self.DEFAULT_IMAGE)
+        modules_url = '%s/%s' % (config_url, self.DEFAULT_MODULES)
+        dtb_url = '%s/dtbs/%s.dtb' % (config_url, self.DEFAULT_DTB)
+        release_response = {
+            'result': [{'kernel': self.DEFAULT_RELEASE}],
+        }
+        release_headers = {
+            'Authorization': self.DEFAULT_API_TOKEN,
+        }
+        board = {
+            'arch': self.DEFAULT_ARCH,
+            'dt': self.DEFAULT_DTB,
+            'name': 'test'
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(release_url, json=release_response,
+                 request_headers=release_headers)
+        mock.get(config_url)
+        mock.get(kernel_url)
+        mock.get(modules_url)
+        mock.get(dtb_url)
+
+        crawler = KernelCICrawler(cfg)
+        items = crawler.crawl(board, self.DEFAULT_TREE,
+                              self.DEFAULT_BRANCH,
+                              self.DEFAULT_DEFCONFIG)
+
+        assert_equal(kernel_url, items['kernel'])
+        assert_equal(dtb_url, items['dtb'])
+        assert_equal(modules_url, items['modules'])
+
+    @requests_mock.mock()
+    def test_check_artifacts_all_missing_config(self, mock):
+        release_url = self.RELEASE_URL % (
+            self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+        config_url = '%s/%s/%s/%s/%s/%s' % (self.BASE_URL,
+                                            self.DEFAULT_TREE,
+                                            self.DEFAULT_BRANCH,
+                                            self.DEFAULT_RELEASE,
+                                            self.DEFAULT_ARCH,
+                                            self.DEFAULT_DEFCONFIG)
+        release_response = {
+            'result': [{'kernel': self.DEFAULT_RELEASE}],
+        }
+        release_headers = {
+            'Authorization': self.DEFAULT_API_TOKEN,
+        }
+        board = {
+            'arch': self.DEFAULT_ARCH,
+            'dt': self.DEFAULT_DTB,
+            'name': 'test'
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(release_url, json=release_response,
+                 request_headers=release_headers)
+        mock.get(config_url, status_code=404)
+
+        crawler = KernelCICrawler(cfg)
+        assert_raises(RemoteAccessError, crawler.crawl,
+                      board, self.DEFAULT_TREE, self.DEFAULT_BRANCH,
+                      self.DEFAULT_DEFCONFIG)
+
+    @requests_mock.mock()
+    def test_check_artifacts_all_missing_kernel(self, mock):
+        release_url = self.RELEASE_URL % (
+            self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+        config_url = '%s/%s/%s/%s/%s/%s' % (self.BASE_URL,
+                                            self.DEFAULT_TREE,
+                                            self.DEFAULT_BRANCH,
+                                            self.DEFAULT_RELEASE,
+                                            self.DEFAULT_ARCH,
+                                            self.DEFAULT_DEFCONFIG)
+        kernel_url = '%s/%s' % (config_url, self.DEFAULT_IMAGE)
+        release_response = {
+            'result': [{'kernel': self.DEFAULT_RELEASE}],
+        }
+        release_headers = {
+            'Authorization': self.DEFAULT_API_TOKEN,
+        }
+        board = {
+            'arch': self.DEFAULT_ARCH,
+            'dt': self.DEFAULT_DTB,
+            'name': 'test'
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(release_url, json=release_response,
+                 request_headers=release_headers)
+        mock.get(config_url)
+        mock.get(kernel_url, status_code=404)
+
+        crawler = KernelCICrawler(cfg)
+        assert_raises(RemoteAccessError, crawler.crawl,
+                      board, self.DEFAULT_TREE, self.DEFAULT_BRANCH,
+                      self.DEFAULT_DEFCONFIG)
+
+    @requests_mock.mock()
+    def test_check_artifacts_all_missing_modules(self, mock):
+        release_url = self.RELEASE_URL % (
+            self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+        config_url = '%s/%s/%s/%s/%s/%s' % (self.BASE_URL,
+                                            self.DEFAULT_TREE,
+                                            self.DEFAULT_BRANCH,
+                                            self.DEFAULT_RELEASE,
+                                            self.DEFAULT_ARCH,
+                                            self.DEFAULT_DEFCONFIG)
+        kernel_url = '%s/%s' % (config_url, self.DEFAULT_IMAGE)
+        modules_url = '%s/%s' % (config_url, self.DEFAULT_MODULES)
+        release_response = {
+            'result': [{'kernel': self.DEFAULT_RELEASE}],
+        }
+        release_headers = {
+            'Authorization': self.DEFAULT_API_TOKEN,
+        }
+        board = {
+            'arch': self.DEFAULT_ARCH,
+            'dt': self.DEFAULT_DTB,
+            'name': 'test'
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(release_url, json=release_response,
+                 request_headers=release_headers)
+        mock.get(config_url)
+        mock.get(kernel_url)
+        mock.get(modules_url, status_code=404)
+
+        crawler = KernelCICrawler(cfg)
+        assert_raises(RemoteAccessError, crawler.crawl,
+                      board, self.DEFAULT_TREE, self.DEFAULT_BRANCH,
+                      self.DEFAULT_DEFCONFIG)
+
+    @requests_mock.mock()
+    def test_check_artifacts_all_missing_dtb(self, mock):
+        release_url = self.RELEASE_URL % (
+            self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+        config_url = '%s/%s/%s/%s/%s/%s' % (self.BASE_URL,
+                                            self.DEFAULT_TREE,
+                                            self.DEFAULT_BRANCH,
+                                            self.DEFAULT_RELEASE,
+                                            self.DEFAULT_ARCH,
+                                            self.DEFAULT_DEFCONFIG)
+        kernel_url = '%s/%s' % (config_url, self.DEFAULT_IMAGE)
+        modules_url = '%s/%s' % (config_url, self.DEFAULT_MODULES)
+        dtb_url = '%s/dtbs/%s.dtb' % (config_url, self.DEFAULT_DTB)
+        release_response = {
+            'result': [{'kernel': self.DEFAULT_RELEASE}],
+        }
+        release_headers = {
+            'Authorization': self.DEFAULT_API_TOKEN,
+        }
+        board = {
+            'arch': self.DEFAULT_ARCH,
+            'dt': self.DEFAULT_DTB,
+            'name': 'test'
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(release_url, json=release_response,
+                 request_headers=release_headers)
+        mock.get(config_url)
+        mock.get(kernel_url)
+        mock.get(modules_url)
+        mock.get(dtb_url, status_code=404)
+
+        crawler = KernelCICrawler(cfg)
+        assert_raises(RemoteAccessError, crawler.crawl,
+                      board, self.DEFAULT_TREE, self.DEFAULT_BRANCH,
+                      self.DEFAULT_DEFCONFIG)
+
+
+class TestFECrawler(object):
+    BASE_URL = 'http://lava.free-electrons.com/downloads/builds/'
+    DEFAULT_API_TOKEN = 'foobar42'
+    DEFAULT_ARCH = 'arm'
+    DEFAULT_BRANCH = 'master'
+    DEFAULT_DEFCONFIG = 'test_defconfig'
+    DEFAULT_DTB = 'test'
+    DEFAULT_IMAGE = 'zImage'
+    DEFAULT_MODULES = 'modules.tar.xz'
+    DEFAULT_RELEASE = 'version-deadcoffee-4.2'
+    DEFAULT_TREE = 'mainline'
+
+    @requests_mock.mock()
+    def test_check_release(self, mock):
+        url = '%s/%s/%s/latest' % (self.BASE_URL,
+                                   self.DEFAULT_TREE,
+                                   self.DEFAULT_BRANCH)
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(url, text=self.DEFAULT_RELEASE)
+
+        crawler = FreeElectronsCrawler(cfg)
+        assert_equal(self.DEFAULT_RELEASE,
+                     crawler._get_latest_release(self.DEFAULT_TREE,
+                                                 self.DEFAULT_BRANCH))
+
+    @requests_mock.mock()
+    def test_check_release_error(self, mock):
+        url = '%s/%s/%s/latest' % (self.BASE_URL,
+                                   self.DEFAULT_TREE,
+                                   self.DEFAULT_BRANCH)
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(url, status_code=404)
+
+        crawler = FreeElectronsCrawler(cfg)
+        assert_raises(RemoteAccessError, crawler._get_latest_release,
+                      self.DEFAULT_TREE, self.DEFAULT_BRANCH)
+
+    @requests_mock.mock()
+    def test_check_release_url(self, mock):
+        url = '%s/%s/%s/latest' % (self.BASE_URL,
+                                   self.DEFAULT_TREE,
+                                   self.DEFAULT_BRANCH)
+        base_url = '%s/%s/%s/%s/%s/%s' % (self.BASE_URL,
+                                          self.DEFAULT_TREE,
+                                          self.DEFAULT_BRANCH,
+                                          self.DEFAULT_RELEASE,
+                                          self.DEFAULT_ARCH,
+                                          self.DEFAULT_DEFCONFIG)
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(url, text=self.DEFAULT_RELEASE)
+
+        crawler = FreeElectronsCrawler(cfg)
+        assert_equal(base_url, crawler._get_base_url(self.DEFAULT_TREE,
+                                                     self.DEFAULT_BRANCH,
+                                                     self.DEFAULT_ARCH,
+                                                     self.DEFAULT_DEFCONFIG))
+
+    @requests_mock.mock()
+    def test_check_artifacts_all(self, mock):
+        release_url = '%s/%s/%s/latest' % (self.BASE_URL,
+                                           self.DEFAULT_TREE,
+                                           self.DEFAULT_BRANCH)
+        config_url = '%s/%s/%s/%s/%s/%s' % (self.BASE_URL,
+                                            self.DEFAULT_TREE,
+                                            self.DEFAULT_BRANCH,
+                                            self.DEFAULT_RELEASE,
+                                            self.DEFAULT_ARCH,
+                                            self.DEFAULT_DEFCONFIG)
+        kernel_url = '%s/%s' % (config_url, self.DEFAULT_IMAGE)
+        modules_url = '%s/%s' % (config_url, self.DEFAULT_MODULES)
+        dtb_url = '%s/dtbs/%s.dtb' % (config_url, self.DEFAULT_DTB)
+        board = {
+            'arch': self.DEFAULT_ARCH,
+            'dt': self.DEFAULT_DTB,
+            'name': 'test'
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(release_url, text=self.DEFAULT_RELEASE)
+        mock.get(config_url)
+        mock.get(kernel_url)
+        mock.get(modules_url)
+        mock.get(dtb_url)
+
+        crawler = FreeElectronsCrawler(cfg)
+        items = crawler.crawl(board, self.DEFAULT_TREE,
+                              self.DEFAULT_BRANCH,
+                              self.DEFAULT_DEFCONFIG)
+
+        assert_equal(kernel_url, items['kernel'])
+        assert_equal(dtb_url, items['dtb'])
+        assert_equal(modules_url, items['modules'])
+
+    @requests_mock.mock()
+    def test_check_artifacts_all_missing_config(self, mock):
+        release_url = '%s/%s/%s/latest' % (self.BASE_URL,
+                                           self.DEFAULT_TREE,
+                                           self.DEFAULT_BRANCH)
+        config_url = '%s/%s/%s/%s/%s/%s' % (self.BASE_URL,
+                                            self.DEFAULT_TREE,
+                                            self.DEFAULT_BRANCH,
+                                            self.DEFAULT_RELEASE,
+                                            self.DEFAULT_ARCH,
+                                            self.DEFAULT_DEFCONFIG)
+        board = {
+            'arch': self.DEFAULT_ARCH,
+            'dt': self.DEFAULT_DTB,
+            'name': 'test'
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(release_url, text=self.DEFAULT_RELEASE)
+        mock.get(config_url, status_code=404)
+
+        crawler = FreeElectronsCrawler(cfg)
+        assert_raises(RemoteAccessError, crawler.crawl,
+                      board, self.DEFAULT_TREE, self.DEFAULT_BRANCH,
+                      self.DEFAULT_DEFCONFIG)
+
+    @requests_mock.mock()
+    def test_check_artifacts_all_missing_kernel(self, mock):
+        release_url = '%s/%s/%s/latest' % (self.BASE_URL,
+                                           self.DEFAULT_TREE,
+                                           self.DEFAULT_BRANCH)
+        config_url = '%s/%s/%s/%s/%s/%s' % (self.BASE_URL,
+                                            self.DEFAULT_TREE,
+                                            self.DEFAULT_BRANCH,
+                                            self.DEFAULT_RELEASE,
+                                            self.DEFAULT_ARCH,
+                                            self.DEFAULT_DEFCONFIG)
+        kernel_url = '%s/%s' % (config_url, self.DEFAULT_IMAGE)
+        board = {
+            'arch': self.DEFAULT_ARCH,
+            'dt': self.DEFAULT_DTB,
+            'name': 'test'
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(release_url, text=self.DEFAULT_RELEASE)
+        mock.get(config_url)
+        mock.get(kernel_url, status_code=404)
+
+        crawler = FreeElectronsCrawler(cfg)
+        assert_raises(RemoteAccessError, crawler.crawl,
+                      board, self.DEFAULT_TREE, self.DEFAULT_BRANCH,
+                      self.DEFAULT_DEFCONFIG)
+
+    @requests_mock.mock()
+    def test_check_artifacts_all_missing_modules(self, mock):
+        release_url = '%s/%s/%s/latest' % (self.BASE_URL,
+                                           self.DEFAULT_TREE,
+                                           self.DEFAULT_BRANCH)
+        config_url = '%s/%s/%s/%s/%s/%s' % (self.BASE_URL,
+                                            self.DEFAULT_TREE,
+                                            self.DEFAULT_BRANCH,
+                                            self.DEFAULT_RELEASE,
+                                            self.DEFAULT_ARCH,
+                                            self.DEFAULT_DEFCONFIG)
+        kernel_url = '%s/%s' % (config_url, self.DEFAULT_IMAGE)
+        modules_url = '%s/%s' % (config_url, self.DEFAULT_MODULES)
+        board = {
+            'arch': self.DEFAULT_ARCH,
+            'dt': self.DEFAULT_DTB,
+            'name': 'test'
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(release_url, text=self.DEFAULT_RELEASE)
+        mock.get(config_url)
+        mock.get(kernel_url)
+        mock.get(modules_url, status_code=404)
+
+        crawler = FreeElectronsCrawler(cfg)
+        assert_raises(RemoteAccessError, crawler.crawl,
+                      board, self.DEFAULT_TREE, self.DEFAULT_BRANCH,
+                      self.DEFAULT_DEFCONFIG)
+
+    @requests_mock.mock()
+    def test_check_artifacts_all_missing_dtb(self, mock):
+        release_url = '%s/%s/%s/latest' % (self.BASE_URL,
+                                           self.DEFAULT_TREE,
+                                           self.DEFAULT_BRANCH)
+        config_url = '%s/%s/%s/%s/%s/%s' % (self.BASE_URL,
+                                            self.DEFAULT_TREE,
+                                            self.DEFAULT_BRANCH,
+                                            self.DEFAULT_RELEASE,
+                                            self.DEFAULT_ARCH,
+                                            self.DEFAULT_DEFCONFIG)
+        kernel_url = '%s/%s' % (config_url, self.DEFAULT_IMAGE)
+        modules_url = '%s/%s' % (config_url, self.DEFAULT_MODULES)
+        dtb_url = '%s/dtbs/%s.dtb' % (config_url, self.DEFAULT_DTB)
+        board = {
+            'arch': self.DEFAULT_ARCH,
+            'dt': self.DEFAULT_DTB,
+            'name': 'test'
+        }
+        cfg = {
+            'api_token': self.DEFAULT_API_TOKEN,
+        }
+
+        mock.get(release_url, text=self.DEFAULT_RELEASE)
+        mock.get(config_url)
+        mock.get(kernel_url)
+        mock.get(modules_url)
+        mock.get(dtb_url, status_code=404)
+
+        crawler = FreeElectronsCrawler(cfg)
+        assert_raises(RemoteAccessError, crawler.crawl,
+                      board, self.DEFAULT_TREE, self.DEFAULT_BRANCH,
+                      self.DEFAULT_DEFCONFIG)

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -1,0 +1,138 @@
+from nose.tools import assert_equal, assert_raises
+import mock
+import xmlrpc
+
+from src.writers import FileWriter, LavaWriter
+from src.writers import UnavailableError
+
+
+class TestFileWriter(object):
+    OUTPUT_DIR = 'foo'
+    CONTENT = 'test'
+    NAME = 'test-job-name'
+
+    def test_fail_open(self):
+        cfg = {
+            'output_dir': self.OUTPUT_DIR,
+        }
+
+        mo = mock.mock_open()
+        with mock.patch('builtins.open', mo, create=True) as mocked:
+            mocked.side_effect = IOError
+
+            writer = FileWriter(cfg)
+            assert_raises(UnavailableError, writer.write, dict(),
+                          self.NAME, self.CONTENT)
+
+    def test_write(self):
+        cfg = {
+            'output_dir': self.OUTPUT_DIR,
+        }
+
+        mo = mock.mock_open(read_data=self.CONTENT)
+        with mock.patch('builtins.open', mo, create=True) as mocked:
+            path = '%s/%s.yaml' % (self.OUTPUT_DIR, self.NAME)
+            mocked_file = mocked.return_value
+
+            writer = FileWriter(cfg)
+            results = writer.write(dict(), self.NAME, self.CONTENT)
+
+            mocked.assert_called_once_with(path, 'w')
+            mocked_file.write.assert_called_with(self.CONTENT)
+            assert_equal(results, [path])
+
+
+class TestLavaWriter(object):
+    DEVICE_TYPE = 'foo_bar'
+    CONTENT = 'test'
+    NAME = 'test-job-name'
+    UI_ADDRESS = 'http://webui.example.org'
+
+    @mock.patch('xmlrpc.client.ServerProxy')
+    def test_connection_error(self, mock):
+        board = {
+            'device_type': self.DEVICE_TYPE,
+        }
+        cfg = {
+            'server': 'https://test.example.org/RPC2',
+            'username': 'foobar',
+            'token': 'deadcoffee42',
+        }
+        response = {
+            'status': 'offline',
+        }
+
+        mock.side_effect = xmlrpc.client.Error
+        assert_raises(UnavailableError, LavaWriter, cfg)
+
+    @mock.patch('xmlrpc.client.ServerProxy')
+    def test_device_offline(self, mock):
+        board = {
+            'device_type': self.DEVICE_TYPE,
+        }
+        cfg = {
+            'server': 'https://test.example.org/RPC2',
+            'username': 'foobar',
+            'token': 'deadcoffee42',
+        }
+        response = {
+            'status': 'offline',
+        }
+
+        mock_proxy = mock.return_value
+        mock_proxy.scheduler.get_device_status.return_value = response
+
+        writer = LavaWriter(cfg)
+        assert_raises(UnavailableError, writer.write, board,
+                      self.NAME, self.CONTENT)
+
+    @mock.patch('xmlrpc.client.ServerProxy')
+    def test_write_unique(self, mock):
+        board = {
+            'device_type': self.DEVICE_TYPE,
+        }
+        cfg = {
+            'server': 'https://test.example.org/RPC2',
+            'username': 'foobar',
+            'token': 'deadcoffee42',
+            'web_ui_address': self.UI_ADDRESS,
+        }
+        response = {
+            'status': 'online',
+        }
+
+        mock_proxy = mock.return_value
+        mock_proxy.scheduler.submit_job.return_value = 42
+
+        writer = LavaWriter(cfg)
+        results = writer.write(board, self.NAME, self.CONTENT)
+
+        mock_proxy.scheduler.get_device_status.assert_called_with('%s_01' % self.DEVICE_TYPE)
+        mock_proxy.scheduler.submit_job.assert_called_with(self.CONTENT)
+        assert_equal(results, ['%s/scheduler/job/%d' % (self.UI_ADDRESS, 42)])
+
+    @mock.patch('xmlrpc.client.ServerProxy')
+    def test_write_multiple(self, mock):
+        board = {
+            'device_type': self.DEVICE_TYPE,
+        }
+        cfg = {
+            'server': 'https://test.example.org/RPC2',
+            'username': 'foobar',
+            'token': 'deadcoffee42',
+            'web_ui_address': self.UI_ADDRESS,
+        }
+        response = {
+            'status': 'online',
+        }
+
+        mock_proxy = mock.return_value
+        mock_proxy.scheduler.submit_job.return_value = (42, 84)
+
+        writer = LavaWriter(cfg)
+        results = writer.write(board, self.NAME, self.CONTENT)
+
+        mock_proxy.scheduler.get_device_status.assert_called_with('%s_01' % self.DEVICE_TYPE)
+        mock_proxy.scheduler.submit_job.assert_called_with(self.CONTENT)
+        assert_equal(results, ['%s/scheduler/job/%d' % (self.UI_ADDRESS, 42),
+                               '%s/scheduler/job/%d' % (self.UI_ADDRESS, 84)])

--- a/utils.py
+++ b/utils.py
@@ -1,36 +1,9 @@
-import urllib.request
-import urllib.error
-import urllib.parse
-
-import xmlrpc.client
-import ssl
-
 import os
 import logging
 
 import sys
 
 import paramiko
-
-def get_connection(cfg):
-    u = urllib.parse.urlparse(cfg['server'])
-    url = "%s://%s:%s@%s/RPC2" % (u.scheme,
-                                  cfg['username'],
-                                  cfg['token'],
-                                  u.netloc)
-
-    # Taken from Lavabo: https://github.com/free-electrons/lavabo/blob/master/utils.py#L88
-    try:
-        if 'https' == u.scheme:
-            context = hasattr(ssl, '_create_unverified_context') and ssl._create_unverified_context() or None
-            connection = xmlrpc.client.ServerProxy(url,
-                    transport=xmlrpc.client.SafeTransport(use_datetime=True, context=context))
-        else:
-            connection = xmlrpc.client.ServerProxy(url)
-        return connection
-    except (xmlrpc.client.ProtocolError, xmlrpc.client.Fault, IOError) as e:
-        logging.error("Unable to connect to %s" % url)
-        sys.exit(1)
 
 # The next three function are borrowed from Lavabo, thx Oleil! :)
 def get_hostkey(hostname):


### PR DESCRIPTION
This branch splits out the job output logic in classes of their own.

Even though the Github UI doesn't seem to understand it, this is based on the current crawler PR.