### PR TITLE
Move "offline"/"retired" check before sending jobs

### DIFF
--- a/ci_launcher.py
+++ b/ci_launcher.py
@@ -48,6 +48,15 @@ class CILauncher(BaseLauncher):
             if not self._tests_config[board]['tests']:
                 logging.info("  No test set")
 
+            # Retrieve the device status
+            dev = self.crafter.get_device_status(board)
+            if dev['status'] == "offline":
+                logging.error("Device is offline, not sending jobs")
+                return
+            elif dev['status'] == "retired":
+                logging.error("Device is retired, not sending jobs")
+                return
+
             try:
                 rootfs = RootfsChooser().get_url(self._boards_config[board])
             except RootfsAccessError as e:

--- a/src/crafter.py
+++ b/src/crafter.py
@@ -58,6 +58,9 @@ class JobCrafter(object):
         else:
             self.writer = LavaWriter(self._cfg)
 
+    def get_device_status(self, device):
+        return self.writer.query_device_status(device)
+
 # Template handling
     def get_template_from_file(self, file):
         logging.debug("    Template: %s" % file)

--- a/src/writers.py
+++ b/src/writers.py
@@ -80,19 +80,12 @@ class LavaWriter(Writer):
         except xmlrpc.client.Error:
             raise UnavailableError('LAVA device is offline')
 
-    def __get_device_status(self, device):
+    def query_device_status(self, device):
         board = "%s_01" % device
 
         return self._con.scheduler.get_device_status(board)
 
     def write(self, board, name, job):
-        dev = self.__get_device_status(board['device_type'])
-        if dev['status'] == "offline":
-            logging.error("Device is offline, not sending the job")
-            raise UnavailableError('LAVA device is offline')
-        elif dev['status'] == "retired":
-            logging.error("Device is retired, not sending the job")
-            raise UnavailableError('LAVA device is retired')
 
         value = list()
         #


### PR DESCRIPTION
Hello,

This commit moves the offline/retired verification before
trying to send jobs. Thanks to that, we will directly know
the board status and not for each job.

I am not a Python developer so any review is welcomed.

Signed-off-by: Mylène Josserand <mylene.josserand@free-electrons.com>